### PR TITLE
defined default action

### DIFF
--- a/app/code/community/Conlabz/CrConnect/controllers/SearchController.php
+++ b/app/code/community/Conlabz/CrConnect/controllers/SearchController.php
@@ -17,7 +17,7 @@ class Conlabz_CrConnect_SearchController extends Mage_Core_Controller_Front_Acti
         }
 
         $search = Mage::getModel('crconnect/search');
-        $action = $this->getRequest()->getParam('get');
+        $action = $this->getRequest()->getParam('get', 'filter');
         $returnData = array();
         switch ($action) {
             case 'filter':


### PR DESCRIPTION
The hint says one should use `https://www.meinshop.de/index.php/crconnect/search/index/store/1/`. This does not work as no action is defined. This PR fixes this issue by defining filter as the default action.