### PR TITLE
fixed multistore search

### DIFF
--- a/app/code/community/Conlabz/CrConnect/controllers/SearchController.php
+++ b/app/code/community/Conlabz/CrConnect/controllers/SearchController.php
@@ -16,6 +16,9 @@ class Conlabz_CrConnect_SearchController extends Mage_Core_Controller_Front_Acti
             exit;
         }
 
+        // make sure to set the correct store, so that correct categories and products are used
+        Mage::app()->setCurrentStore($store);
+
         $search = Mage::getModel('crconnect/search');
         $action = $this->getRequest()->getParam('get');
         $returnData = array();


### PR DESCRIPTION
There can be a wrong root cat ID in `Conlabz_CrConnect_Model_Search#getFilter` if you have a multistore environment. This PR fixes this issue.