### PR TITLE
fixed exception logging during order placement

### DIFF
--- a/app/code/community/Conlabz/CrConnect/Model/Observer.php
+++ b/app/code/community/Conlabz/CrConnect/Model/Observer.php
@@ -189,7 +189,7 @@ class Conlabz_CrConnect_Model_Observer
             }
         } catch (Exception $ex) {
             Mage::helper("crconnect")->log("order_save_after Exception");
-            Mage::helper("crconnect")->log($ex);
+            Mage::helper("crconnect")->log($ex->getMessage());
         }
         return true;
     }


### PR DESCRIPTION
The current exception "logging" does not work and breaks the checkout. For certain payment methods like PayPal, money will be transmitted, but no Magento order will be created due to this issue!!!